### PR TITLE
Expose the gchat notification

### DIFF
--- a/cekit-cache-server/README.md
+++ b/cekit-cache-server/README.md
@@ -31,7 +31,7 @@ org.kie.cekit.cacher.github.default.branch - rhpam and rhdm upstream default bra
 
 # google chat room webhook conf
 # be sure to scape special characters
-org.kie.cekit.cacher.hangouts.webhook - The Google hangout webhook for a target room or chat, can be obtained on the room.
+org.kie.cekit.cacher.gchat.webhook - The Google Chat webhook for a target room or chat, can be obtained on the room.
 that you want to send notification.
 ```
 

--- a/cekit-cache-server/cekit-cacher-template.yaml
+++ b/cekit-cache-server/cekit-cacher-template.yaml
@@ -71,9 +71,9 @@ parameters:
     description: "The Google Chats user id, just use the ID in this field, ignore the 'user/' prefix"
     name: CACHER_GITHUB_REVIEWERS
     required: false
-  - displayName: Cacher Hangouts Webhook
-    description: "The Google hangout webhook for a target room or chat, can be obtained on the room"
-    name: CACHER_HANGOUTS_WEBHOOK
+  - displayName: Cacher GChat Webhook
+    description: "The Google chat webhook for a target room or chat, can be obtained on the room"
+    name: CACHER_GCHAT_WEBHOOK
     required: false
   - displayName: ImageStream Namespace
     description: "Namespace in which the ImageStreams for Cacher image is installed"
@@ -195,8 +195,8 @@ objects:
                   value: "${CACHER_DEFAULT_BRANCH}"
                 - name: CACHER_GITHUB_REVIEWERS
                   value: "${CACHER_GITHUB_REVIEWERS}"
-                - name: CACHER_HANGOUTS_WEBHOOK
-                  value: "${CACHER_HANGOUTS_WEBHOOK}"
+                - name: CACHER_GCHAT_WEBHOOK
+                  value: "${CACHER_GCHAT_WEBHOOK}"
 
           volumes:
             - name: "${APPLICATION_NAME}-volume"

--- a/cekit-cache-server/pom.xml
+++ b/cekit-cache-server/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-validator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
       <version>${okhttp.version}</version>

--- a/cekit-cache-server/src/main/java/org/kie/cekit/cacher/builds/github/PullRequestSender.java
+++ b/cekit-cache-server/src/main/java/org/kie/cekit/cacher/builds/github/PullRequestSender.java
@@ -88,10 +88,10 @@ public class PullRequestSender {
                 message.append("\n");
                 message.append(notification.link(object.getString("html_url"), "Click here to access the Pull Request"));
                 message.append("\n");
-                message.append(notification.mention(cacherProperties.githubReviewers()));
+                message.append("Reviewers please take a look: " + notification.mention(cacherProperties.githubReviewers()));
 
                 log.fine(message.toString());
-                notification.send(message.toString(), cacherProperties.hangoutsWebhook());
+                notification.send(message.toString(), cacherProperties.gChatWebhook());
                 return true;
             } else {
                 message.append("Failed to created PR against ");
@@ -99,14 +99,14 @@ public class PullRequestSender {
                 message.append(notification.monospaceBlock(object.getString("message") +
                         ". Reason: " + object.getJsonArray("errors").getJsonObject(0).getString("message")));
 
-                notification.send(message.toString(), cacherProperties.hangoutsWebhook());
+                notification.send(message.toString(), cacherProperties.gChatWebhook());
 
                 return false;
             }
 
         } catch (final Exception e) {
             notification.send("Failed to submit PR against " + repo + " - *reason: " + notification.bold(e.getMessage()),
-                    cacherProperties.hangoutsWebhook() + "*");
+                    cacherProperties.gChatWebhook() + "*");
             e.printStackTrace();
             return false;
         }

--- a/cekit-cache-server/src/main/java/org/kie/cekit/cacher/notification/Notification.java
+++ b/cekit-cache-server/src/main/java/org/kie/cekit/cacher/notification/Notification.java
@@ -3,10 +3,10 @@ package org.kie.cekit.cacher.notification;
 public interface Notification {
 
     /**
-     * Exposes notification method for hangout chat, webhook is required.
+     * Exposes notification method for Google chat, webhook is required.
      *
      * @param message
-     * @param webhook - Enables the incoming webhook for hangouts chat notification
+     * @param webhook - Enables the incoming webhook for Google chat notification
      *                it should be enabled by room.
      */
     void send(String message, String webhook);
@@ -79,7 +79,7 @@ public interface Notification {
      * @return mention formatted text
      */
     default String mention(String[] userIds) {
-        StringBuilder text = new StringBuilder("Reviewers please take a look:");
+        StringBuilder text = new StringBuilder();
         for (String userId : userIds) {
             text.append( " <users/" + userId + ">");
         }

--- a/cekit-cache-server/src/main/java/org/kie/cekit/cacher/notification/gchat/GChatNotifier.java
+++ b/cekit-cache-server/src/main/java/org/kie/cekit/cacher/notification/gchat/GChatNotifier.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 @ApplicationScoped
-public class HangoutsChatNotifier implements Notification {
+public class GChatNotifier implements Notification {
 
     private Logger log = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
     private final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
@@ -38,7 +38,7 @@ public class HangoutsChatNotifier implements Notification {
 
         try (Response response = client.newCall(request).execute()) {
             if (response.code() == 200) {
-                log.fine("Hangout chat notification sent.");
+                log.fine("Google chat notification sent.");
             } else {
                 log.fine("Failed to send notification " + response.body().string());
             }

--- a/cekit-cache-server/src/main/java/org/kie/cekit/cacher/objects/GChatMessage.java
+++ b/cekit-cache-server/src/main/java/org/kie/cekit/cacher/objects/GChatMessage.java
@@ -1,0 +1,58 @@
+package org.kie.cekit.cacher.objects;
+
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+
+public class GChatMessage {
+
+    @NotEmpty(message = "At least one user must be notified")
+    private List<String> recipients;
+    @NotEmpty(message = "The message body is missing")
+    private String message;
+    @NotEmpty(message = "You must identify yourself :)")
+    private String from;
+    @NotEmpty(message = "Seems this message is useless since there is no subject :)")
+    private String subject;
+
+    public List<String> getRecipients() {
+        return recipients;
+    }
+
+    public void setRecipients(List<String> recipients) {
+        this.recipients = recipients;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    @Override
+    public String toString() {
+        return "GChatMessage{" +
+                "receipts=" + recipients +
+                ", message='" + message + '\'' +
+                ", from='" + from + '\'' +
+                ", subject='" + subject + '\'' +
+                '}';
+    }
+}

--- a/cekit-cache-server/src/main/java/org/kie/cekit/cacher/properties/CacherProperties.java
+++ b/cekit-cache-server/src/main/java/org/kie/cekit/cacher/properties/CacherProperties.java
@@ -63,8 +63,8 @@ public class CacherProperties {
     String version;
 
     @Inject
-    @CacherProperty(name = "org.kie.cekit.cacher.hangouts.webhook")
-    String hangoutsWebhook;
+    @CacherProperty(name = "org.kie.cekit.cacher.gchat.webhook")
+    String gChatWebhook;
 
     @Inject
     @CacherProperty(name = "org.kie.cekit.cacher.enable.nightly.watcher")
@@ -194,10 +194,10 @@ public class CacherProperties {
     }
 
     /**
-     * @return hangout webhook address to send notifications
+     * @return Google Chat webhook address to send notifications
      */
-    public String hangoutsWebhook() {
-        return hangoutsWebhook;
+    public String gChatWebhook() {
+        return gChatWebhook;
     }
 
     /**

--- a/cekit-cache-server/src/main/java/org/kie/cekit/cacher/resources/NotificationResource.java
+++ b/cekit-cache-server/src/main/java/org/kie/cekit/cacher/resources/NotificationResource.java
@@ -1,0 +1,80 @@
+package org.kie.cekit.cacher.resources;
+
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.kie.cekit.cacher.notification.Notification;
+import org.kie.cekit.cacher.objects.GChatMessage;
+import org.kie.cekit.cacher.properties.CacherProperties;
+
+import javax.inject.Inject;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Array;
+import java.util.Set;
+import java.util.logging.Logger;
+
+@Path("/notification")
+public class NotificationResource {
+
+    private Logger log = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
+    private static final Validator VALIDATOR =
+            Validation.byDefaultProvider()
+                    .configure()
+                    .messageInterpolator(new ParameterMessageInterpolator())
+                    .buildValidatorFactory()
+                    .getValidator();
+
+    @Inject
+    CacherProperties property;
+
+    @Inject
+    Notification notification;
+
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/send")
+    public Response notify(GChatMessage message) {
+
+        if (null == property.gChatWebhook()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity("Please set the org.kie.cekit.cacher.gchat.webhook property.").build();
+        }
+
+        Set<ConstraintViolation<GChatMessage>> violations = VALIDATOR.validate(message);
+        if (violations.size() > 0) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(violations).build();
+        }
+
+        log.fine(String.format("Sending notification to configured webhook, message From: [%s], Subject: [%s], Receipts: [%s], Text: [%s].",
+                message.getFrom(),
+                message.getSubject(),
+                message.getRecipients(),
+                message.getMessage()));
+
+        String[] recipients =  new String[message.getRecipients().size()];
+        recipients = message.getRecipients().toArray(recipients);
+
+        StringBuilder response = new StringBuilder();
+        response.append(notification.mention(recipients) + " f.y.i.:\n");
+        response.append("New message from " + notification.bold(message.getFrom()) + ".\n");
+        response.append("Subject " + notification.bold(message.getSubject()) + ".\n");
+        response.append("Message content:\n " + notification.monospaceBlock(message.getMessage()));
+
+        try {
+            notification.send(response.toString(), property.gChatWebhook());
+            return Response.ok("Message sent").build();
+        } catch (final Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(e.getMessage()).build();
+        }
+    }
+}

--- a/cekit-cache-server/src/main/resources/META-INF/resources/cekit-cacher.properties
+++ b/cekit-cache-server/src/main/resources/META-INF/resources/cekit-cacher.properties
@@ -25,6 +25,6 @@ org.kie.cekit.cacher.github.default.branch=${CACHER_DEFAULT_BRANCH}
 # Google Chat USERID, comma separated, do not add spaces
 org.kie.cekit.cacher.github.reviewers=${CACHER_GITHUB_REVIEWERS}
 
-# Hangout chat conf
+# Google chat conf
 # be sure to scape special characters
-org.kie.cekit.cacher.hangouts.webhook=${CACHER_HANGOUTS_WEBHOOK}
+org.kie.cekit.cacher.gchat.webhook=${CACHER_GCHAT_WEBHOOK}


### PR DESCRIPTION
With Gchat notification small api exposed we can take
advantage of this on nighlty builds on Jenkins t notify us on
GChat if a build has failed.

For its usage take a look on the swagger-ui.

Signed-off-by: Filippe Spolti <fspolti@redhat.com>