### PR TITLE
[KOGITO-4782] - [OSBS] Update Kogito images to use internal rhel repo…

### DIFF
--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/common/Env.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/common/Env.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.common;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/common/Label.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/common/Label.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.common;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/common/Modules.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/common/Modules.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.common;
 
 import java.util.List;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/common/Port.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/common/Port.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/common/Run.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/common/Run.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.common;
 
 import java.util.List;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/container/Compose.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/container/Compose.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.container;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/container/Container.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/container/Container.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.container;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/container/Platforms.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/container/Platforms.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.container;
 
 import java.util.List;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/image/Configuration.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/image/Configuration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.image;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/image/Git.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/image/Git.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.image;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/image/Image.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/image/Image.java
@@ -8,7 +8,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.kie.cekit.image.descriptors.common.Env;
 import org.kie.cekit.image.descriptors.common.Label;
 import org.kie.cekit.image.descriptors.common.Modules;
-import org.kie.cekit.image.descriptors.common.Packages;
+import org.kie.cekit.image.descriptors.packages.Packages;
 import org.kie.cekit.image.descriptors.common.Port;
 import org.kie.cekit.image.descriptors.common.Run;
 

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/image/Install.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/image/Install.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.image;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/image/Osbs.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/image/Osbs.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.image;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/image/Repository.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/image/Repository.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.image;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/module/Artifact.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/module/Artifact.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.module;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/module/Execute.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/module/Execute.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cekit.image.descriptors.module;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/module/Module.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/module/Module.java
@@ -7,7 +7,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.kie.cekit.image.descriptors.common.Env;
 import org.kie.cekit.image.descriptors.common.Label;
 import org.kie.cekit.image.descriptors.common.Modules;
-import org.kie.cekit.image.descriptors.common.Packages;
+import org.kie.cekit.image.descriptors.packages.Packages;
 import org.kie.cekit.image.descriptors.common.Port;
 import org.kie.cekit.image.descriptors.common.Run;
 

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/packages/ContentSets.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/packages/ContentSets.java
@@ -1,5 +1,19 @@
-package org.kie.cekit.image.descriptors;
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package org.kie.cekit.image.descriptors.packages;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/packages/Packages.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/packages/Packages.java
@@ -1,4 +1,19 @@
-package org.kie.cekit.image.descriptors.common;
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.cekit.image.descriptors.packages;
 
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -8,6 +23,8 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
+        "manager",
+        "repositories",
         "content_sets_file",
         "install"
 })
@@ -16,6 +33,8 @@ public class Packages {
 
     @JsonProperty("manager")
     private String manager;
+    @JsonProperty("repositories")
+    private List<Repository> repositories = null;
     @JsonProperty("content_sets_file")
     private String contentSetsFile;
     @JsonProperty("install")

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/packages/Repository.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/packages/Repository.java
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-package org.kie.cekit.image.descriptors.image;
+package org.kie.cekit.image.descriptors.packages;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -23,17 +23,26 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
         "name",
-        "branch"
+        "rpm",
+        "id",
+        "description",
+        "url"
 })
 @RegisterForReflection
-public class RepositoryOsbs {
+public class Repository {
 
     @JsonProperty("name")
     private String name;
-    @JsonProperty("branch")
-    private String branch;
+    @JsonProperty("rpm")
+    private String rpm;
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("description")
+    private String description;
+    @JsonProperty("url")
+    private Url url;
 
-    public RepositoryOsbs(){}
+    public Repository(){}
 
     @JsonProperty("name")
     public String getName() {
@@ -45,14 +54,43 @@ public class RepositoryOsbs {
         this.name = name;
     }
 
-    @JsonProperty("branch")
-    public String getBranch() {
-        return branch;
+    @JsonProperty("rpm")
+    public String getRpm() {
+        return rpm;
     }
 
-    @JsonProperty("branch")
-    public void setBranch(String branch) {
-        this.branch = branch;
+    @JsonProperty("rpm")
+    public void setRpm(String rpm) {
+        this.rpm = rpm;
     }
 
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @JsonProperty("url")
+    public Url getUrl() {
+        return url;
+    }
+
+    @JsonProperty("url")
+    public void setUrl(Url url) {
+        this.url = url;
+    }
 }

--- a/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/packages/Url.java
+++ b/cekit-helpers/cekit-image-descriptors/src/main/java/org/kie/cekit/image/descriptors/packages/Url.java
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-package org.kie.cekit.image.descriptors.image;
+package org.kie.cekit.image.descriptors.packages;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -22,37 +22,23 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-        "name",
-        "branch"
+        "repository"
 })
 @RegisterForReflection
-public class RepositoryOsbs {
+public class Url {
 
-    @JsonProperty("name")
-    private String name;
-    @JsonProperty("branch")
-    private String branch;
+    @JsonProperty("repository")
+    private String repository;
 
-    public RepositoryOsbs(){}
+    public Url(){}
 
-    @JsonProperty("name")
-    public String getName() {
-        return name;
+    @JsonProperty("repository")
+    public String getRepository() {
+        return repository;
     }
 
-    @JsonProperty("name")
-    public void setName(String name) {
-        this.name = name;
+    @JsonProperty("repository")
+    public void setRepository(String repository) {
+        this.repository = repository;
     }
-
-    @JsonProperty("branch")
-    public String getBranch() {
-        return branch;
-    }
-
-    @JsonProperty("branch")
-    public void setBranch(String branch) {
-        this.branch = branch;
-    }
-
 }

--- a/cekit-helpers/cekit-image-validator/README.md
+++ b/cekit-helpers/cekit-image-validator/README.md
@@ -89,7 +89,7 @@ $ mvn quarkus:dev
 
 The application can be packaged using `mvn package`.
 It produces the `cekit-image-validator-1.0-SNAPSHOT-runner.jar` file in the `/target` directory.
-Be aware that it’s not an _über-jar_ as the dependencies are copied into the `target/lib` directory.
+Be aware that it’s not an _uber-jar_ as the dependencies are copied into the `target/lib` directory.
 
 The application is now runnable using `java -jar target/cekit-image-validator-1.0-SNAPSHOT-runner.jar`.
 

--- a/cekit-helpers/cekit-image-validator/src/main/java/org/kie/cekit/image/validator/commands/SingleFileValidator.java
+++ b/cekit-helpers/cekit-image-validator/src/main/java/org/kie/cekit/image/validator/commands/SingleFileValidator.java
@@ -2,7 +2,7 @@ package org.kie.cekit.image.validator.commands;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.kie.cekit.image.descriptors.ContentSets;
+import org.kie.cekit.image.descriptors.packages.ContentSets;
 import org.kie.cekit.image.descriptors.container.Container;
 import org.kie.cekit.image.descriptors.image.Image;
 import org.kie.cekit.image.descriptors.module.Module;


### PR DESCRIPTION
… to get JQ package
See: https://issues.redhat.com/browse/KOGITO-4782

The validator was not recognizing the `repositories` property on the image descriptor:

```

19:22:56 SEVERE Unrecognized field "repositories" (class org.kie.cekit.image.descriptors.common.Packages), not marked as ignorable (3 known properties: "install", "content_sets_file", "manager"])

 at [Source: (sun.nio.ch.ChannelInputStream); line: 52, column: 5] (through reference chain: org.kie.cekit.image.descriptors.image.Image["packages"]->org.kie.cekit.image.descriptors.common.Packages["repositories"])

script returned exit code 1
```

repository key was missing on the validator.
add license where it is missing.

Signed-off-by: spolti <fspolti@redhat.com>